### PR TITLE
Add ToolHive packaged usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,50 @@ Get the config for an OCI image.
 **Output:**
 - The image config
 
+## Usage
+
+### Running with ToolHive (Recommended)
+
+The easiest way to run the OCI Registry MCP server is using [ToolHive](https://github.com/stacklok/toolhive), which provides secure, containerized deployment of MCP servers:
+
+```bash
+# Install ToolHive (if not already installed)
+# See: https://github.com/stacklok/toolhive#installation
+
+# Enable auto-discovery to automatically configure supported clients
+thv config auto-discovery true
+
+# Run the OCI Registry MCP server (packaged as 'oci-registry' in ToolHive)
+thv run oci-registry
+
+# List running servers
+thv list
+
+# Get detailed information about the server
+thv registry info oci-registry
+```
+
+The server will be available to your MCP-compatible clients and can query OCI registries for image information.
+
+#### Authentication with ToolHive
+
+If you need to access private registries, you can provide authentication credentials using ToolHive's secret management:
+
+```bash
+# For bearer token authentication
+thv secret set oci-token
+# Enter your bearer token when prompted
+
+thv run --secret oci-token,target=OCI_TOKEN oci-registry
+
+# For username/password authentication
+thv secret set oci-username
+thv secret set oci-password
+# Enter your credentials when prompted
+
+thv run --secret oci-username,target=OCI_USERNAME --secret oci-password,target=OCI_PASSWORD oci-registry
+```
+
 ## Development
 
 ### Prerequisites


### PR DESCRIPTION
This PR adds instructions for running the OCI Registry MCP server using ToolHive's packaged version.

## Changes

- Add instructions for running OCI Registry MCP server using ToolHive's packaged 'oci-registry' server
- Include ToolHive installation and auto-discovery setup
- Add authentication examples using ToolHive's secret management
- Reorganize usage section to highlight ToolHive as recommended approach
- Maintain existing development and authentication instructions

## Usage

Users can now easily run the OCI Registry MCP server with:

```bash
thv config auto-discovery true
thv run oci-registry
```

For private registries, authentication is simplified using ToolHive's secret management:

```bash
# Bearer token authentication
thv secret set oci-token
thv run --secret oci-token,target=OCI_TOKEN oci-registry

# Username/password authentication
thv secret set oci-username
thv secret set oci-password
thv run --secret oci-username,target=OCI_USERNAME --secret oci-password,target=OCI_PASSWORD oci-registry
```

## Benefits

- Simplified deployment process
- Automatic client configuration
- Secure containerized environment
- Secure secret management for registry authentication
- No need to install Go or build tools
- Consistent with ToolHive's packaged server approach