### PR TITLE
Fix ko build configuration in Taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,3 +52,21 @@ tasks:
     desc: Install dependencies
     cmds:
       - go mod download
+
+  docker-build:
+    desc: Build container image locally using ko
+    cmds:
+      - ko build --local --base-import-paths {{.MAIN_PACKAGE}}
+    env:
+      KO_DOCKER_REPO: '{{.KO_DOCKER_REPO | default "ko.local/ocireg-mcp"}}'
+      VERSION: '{{.VERSION | default "dev"}}'
+      CREATION_TIME: '{{now | date "2006-01-02T15:04:05Z07:00"}}'
+
+  docker-build-multiarch:
+    desc: Build multi-architecture container image using ko
+    cmds:
+      - ko build --local --platform=linux/amd64,linux/arm64 --base-import-paths {{.MAIN_PACKAGE}}
+    env:
+      KO_DOCKER_REPO: '{{.KO_DOCKER_REPO | default "ko.local/ocireg-mcp"}}'
+      VERSION: '{{.VERSION | default "dev"}}'
+      CREATION_TIME: '{{now | date "2006-01-02T15:04:05Z07:00"}}'


### PR DESCRIPTION
## Summary
- Removed `--bare` flag to eliminate conflict with `--base-import-paths`
- Added `VERSION` environment variable with default value "dev"
- Added `CREATION_TIME` environment variable for OCI labels

## Problem
The ko build was failing with two errors:
1. Warning: "Both --base-import-paths and --bare were set"
2. Build failure: "map has no entry for key VERSION"

## Solution
- Removed the conflicting `--bare` flag from both docker build tasks
- Added required environment variables (`VERSION` and `CREATION_TIME`) with sensible defaults
- VERSION can be overridden when needed: `task docker-build VERSION=v1.0.0`

## Test plan
- [ ] Run `task docker-build` and verify it completes without errors
- [ ] Run `task docker-build-multiarch` and verify multi-architecture build works
- [ ] Verify image labels are correctly set with default values

🤖 Generated with [Claude Code](https://claude.com/claude-code)