### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 An MCP (Model Context Protocol) server that provides tools for querying OCI
 registries and image references.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/stackloklabs-ocireg-mcp).
+
 ## Overview
 
 This project implements an SSE-based MCP server that allows LLM-powered


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/stackloklabs-ocireg-mcp)